### PR TITLE
fix: call wasm-pack with nightly via rustup run

### DIFF
--- a/crates/2_with_cc/build_with_wasm_pack.sh
+++ b/crates/2_with_cc/build_with_wasm_pack.sh
@@ -6,7 +6,7 @@
 # please open an Issue or submit PR to update this script.
 
 export RUSTFLAGS="--Z wasm_c_abi=spec"
-wasm-pack build --target web --release
+rustup run nightly wasm-pack build --target web --release
 
 # Optional: Feel free to read the generated WAT file
 wasm2wat pkg/cc_calculator_bg.wasm >pkg/cc_calculator.wat

--- a/crates/3_libc_and_heap_allocation/build_with_wasm_pack.sh
+++ b/crates/3_libc_and_heap_allocation/build_with_wasm_pack.sh
@@ -6,7 +6,7 @@
 # please open an Issue or submit PR to update this script.
 
 export RUSTFLAGS="--Z wasm_c_abi=spec"
-wasm-pack build --target web --release
+rustup run nightly wasm-pack build --target web --release
 
 cp src/memory.js pkg/env.js
 

--- a/crates/4_wasm_bindgen/build_with_wasm_pack.sh
+++ b/crates/4_wasm_bindgen/build_with_wasm_pack.sh
@@ -6,7 +6,7 @@
 # please open an Issue or submit PR to update this script.
 
 export RUSTFLAGS="--Z wasm_c_abi=spec"
-wasm-pack build --target web --release
+rustup run nightly wasm-pack build --target web --release
 
 # Replaces the import statement from 'env' to './env.js'
 sed -i '' "s/from 'env';/from '.\/env.js';/g" pkg/wbg_calculator.js

--- a/crates/5_rust_bindgen/build_with_wasm_pack.sh
+++ b/crates/5_rust_bindgen/build_with_wasm_pack.sh
@@ -6,7 +6,7 @@
 # please open an Issue or submit PR to update this script.
 
 export RUSTFLAGS="--Z wasm_c_abi=spec"
-wasm-pack build --target web --release
+rustup run nightly wasm-pack build --target web --release
 
 # Replaces the import statement from 'env' to './env.js'
 sed -i '' "s/from 'env';/from '.\/env.js';/g" pkg/rbg_calculator.js

--- a/crates/6_extern_types/build_with_wasm_pack.sh
+++ b/crates/6_extern_types/build_with_wasm_pack.sh
@@ -6,7 +6,7 @@
 # please open an Issue or submit PR to update this script.
 
 export RUSTFLAGS="--Z wasm_c_abi=spec"
-wasm-pack build --target web --release
+rustup run nightly wasm-pack build --target web --release
 
 # Replaces the import statement from 'env' to './env.js'
 sed -i '' "s/from 'env';/from '.\/env.js';/g" pkg/ext_t_calculator.js


### PR DESCRIPTION
With wasm-pack 0.13.1 and Rust toolchain on stable 1.85.1, I ran into a build error

```
Error: `cargo metadata` exited with an error: error: failed to run `rustc` to learn about target-specific information

Caused by:
  process didn't exit successfully: `/Users/hbehrens/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc - --crate-name ___ --print=file-names --Z wasm_c_abi=spec --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=split-debuginfo --print=crate-name --print=cfg` (exit status: 1)
  --- stderr
  error: the option `Z` is only accepted on the nightly compiler

  help: consider switching to a nightly toolchain: `rustup default nightly`

  note: selecting a toolchain with `+toolchain` arguments require a rustup proxy; see <https://rust-lang.github.io/rustup/concepts/index.html>

  note: for more information about Rust's stability policy, see <https://doc.rust-lang.org/book/appendix-07-nightly-rust.html#unstable-features>

  error: 1 nightly option were parsed
```

Calling wasm-pack via `rustup run nightly wasm-pack` solves this and the entire `build.sh` completes successfully.

This adjusts the various `build_with_wasm_pack.sh` scripts to do just that for all examples that use wasm-pack.