### PR TITLE
fix: build.rs announces C dependencies

### DIFF
--- a/crates/2_with_cc/build.rs
+++ b/crates/2_with_cc/build.rs
@@ -3,6 +3,7 @@ fn main() {
     build.include("src");
     build.file("src/maths.c");
     build.compile("c_maths");
+    println!("cargo::rerun-if-changed=src/**");
 
     let out_dir = std::env::var("OUT_DIR").unwrap();
     println!("cargo::rustc-link-search=native={}", out_dir);

--- a/crates/2_with_cc/build_with_wasm_pack.sh
+++ b/crates/2_with_cc/build_with_wasm_pack.sh
@@ -6,7 +6,7 @@
 # please open an Issue or submit PR to update this script.
 
 export RUSTFLAGS="--Z wasm_c_abi=spec"
-wasm-pack build --target web --release
+rustup run nightly wasm-pack build --target web --release
 
 # Optional: Feel free to read the generated WAT file
 wasm2wat pkg/cc_calculator_bg.wasm >pkg/cc_calculator.wat

--- a/crates/3_libc_and_heap_allocation/build.rs
+++ b/crates/3_libc_and_heap_allocation/build.rs
@@ -10,4 +10,5 @@ fn main() {
     build.file("src/maths.c");
     build.file("src/memory.c");
     build.compile("c_maths");
+    println!("cargo::rerun-if-changed=src/**");
 }

--- a/crates/3_libc_and_heap_allocation/build_with_wasm_pack.sh
+++ b/crates/3_libc_and_heap_allocation/build_with_wasm_pack.sh
@@ -6,7 +6,7 @@
 # please open an Issue or submit PR to update this script.
 
 export RUSTFLAGS="--Z wasm_c_abi=spec"
-wasm-pack build --target web --release
+rustup run nightly wasm-pack build --target web --release
 
 cp src/memory.js pkg/env.js
 

--- a/crates/4_wasm_bindgen/build.rs
+++ b/crates/4_wasm_bindgen/build.rs
@@ -10,4 +10,5 @@ fn main() {
     build.file("src/calculator.c");
     build.file("src/memory.c");
     build.compile("c_maths");
+    println!("cargo::rerun-if-changed=src/**");
 }

--- a/crates/4_wasm_bindgen/build_with_wasm_pack.sh
+++ b/crates/4_wasm_bindgen/build_with_wasm_pack.sh
@@ -6,7 +6,7 @@
 # please open an Issue or submit PR to update this script.
 
 export RUSTFLAGS="--Z wasm_c_abi=spec"
-wasm-pack build --target web --release
+rustup run nightly wasm-pack build --target web --release
 
 # Replaces the import statement from 'env' to './env.js'
 sed -i '' "s/from 'env';/from '.\/env.js';/g" pkg/wbg_calculator.js

--- a/crates/5_rust_bindgen/build.rs
+++ b/crates/5_rust_bindgen/build.rs
@@ -12,6 +12,7 @@ fn main() {
     build.file("src/calculator.c");
     build.file("src/memory.c");
     build.compile("c_maths");
+    println!("cargo::rerun-if-changed=src/**");
 
     let bindings = bindgen::Builder::default()
         .header("src/calculator.h")

--- a/crates/5_rust_bindgen/build_with_wasm_pack.sh
+++ b/crates/5_rust_bindgen/build_with_wasm_pack.sh
@@ -6,7 +6,7 @@
 # please open an Issue or submit PR to update this script.
 
 export RUSTFLAGS="--Z wasm_c_abi=spec"
-wasm-pack build --target web --release
+rustup run nightly wasm-pack build --target web --release
 
 # Replaces the import statement from 'env' to './env.js'
 sed -i '' "s/from 'env';/from '.\/env.js';/g" pkg/rbg_calculator.js

--- a/crates/6_extern_types/build.rs
+++ b/crates/6_extern_types/build.rs
@@ -10,4 +10,5 @@ fn main() {
     build.file("src/memory.c");
     build.file("src/calculator.c");
     build.compile("c_calculator");
+    println!("cargo::rerun-if-changed=src/**");
 }

--- a/crates/6_extern_types/build_with_wasm_pack.sh
+++ b/crates/6_extern_types/build_with_wasm_pack.sh
@@ -6,7 +6,7 @@
 # please open an Issue or submit PR to update this script.
 
 export RUSTFLAGS="--Z wasm_c_abi=spec"
-wasm-pack build --target web --release
+rustup run nightly wasm-pack build --target web --release
 
 # Replaces the import statement from 'env' to './env.js'
 sed -i '' "s/from 'env';/from '.\/env.js';/g" pkg/ext_t_calculator.js


### PR DESCRIPTION
Changes to the C files in the examples with `cc` crate are now picked up so that calling `build.sh` will no longer a no-op. It does rebuild the sources as expected.